### PR TITLE
[8.x] Add `esCreateIndex()` method to the faker

### DIFF
--- a/src/es-utils/Faker.php
+++ b/src/es-utils/Faker.php
@@ -13,6 +13,28 @@ use Faker\Generator;
  */
 class Faker
 {
+    // Index names
+    private const INDEX_NAMES = [
+        'customers',
+        'staffs',
+        'orders',
+        'stores',
+        'categories',
+        'products',
+        'stocks',
+        'brands',
+        'payments',
+        'invoices',
+        'shipments',
+        'returns',
+        'reviews',
+        'tags',
+        'attributes',
+        'users',
+        'posts',
+        'comments',
+    ];
+
     /**
      * @var Generator
      */
@@ -107,5 +129,33 @@ class Faker
         ];
 
         return array_replace_recursive($data, $info);
+    }
+
+    /**
+     * Generates es create index response
+     *
+     * @param string|null $indexName
+     *
+     * @return array
+     */
+    public function esCreateIndex(?string $indexName = null): array
+    {
+        $indexName = $indexName ?? $this->esIndex();
+
+        return [
+            'acknowledged' => true,
+            'shards_acknowledged' => true,
+            'index' => $indexName,
+        ];
+    }
+
+    /**
+     * Generates es index name
+     *
+     * @return string
+     */
+    public function esIndex(): string
+    {
+        return self::INDEX_NAMES[array_rand(self::INDEX_NAMES)];
     }
 }

--- a/tests/Unit/FakerTest.php
+++ b/tests/Unit/FakerTest.php
@@ -16,6 +16,9 @@ class FakerTest extends TestCase
      */
     private Faker $sut;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         parent::setUp();
@@ -81,6 +84,25 @@ class FakerTest extends TestCase
                 'cluster_uuid' => $clusterUUID,
                 'version' => ['build_hash' => $buildHash],
             ])
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function es_create_index(): void
+    {
+        $indexName = $this->sut->esIndex();
+
+        $expected = [
+            'acknowledged' => true,
+            'shards_acknowledged' => true,
+            'index' => $indexName,
+        ];
+
+        $this->assertEquals(
+            $expected,
+            $this->sut->esCreateIndex($indexName)
         );
     }
 }


### PR DESCRIPTION
This PR adds the `esCreateIndex()` to the faker instance